### PR TITLE
Add WDTFNetData.dll fix for HLK1809

### DIFF
--- a/WDTFNetData_1809/.gitignore
+++ b/WDTFNetData_1809/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!hlk1809-config.json
+!hlk1809server-config.json

--- a/WDTFNetData_1809/hlk1809-config.json
+++ b/WDTFNetData_1809/hlk1809-config.json
@@ -1,0 +1,10 @@
+{
+    "download_url": "",
+    "file_name": "WDTFNetData.dll",
+    "install_cmd": "powershell",
+    "install_args": "-Command \"Copy-Item -Path @sw_path@\\@file_name@ -Destination 'C:\\Program Files\\Windows Kits\\10\\Testing\\Runtimes\\WDTF\\RunTime\\DataPlugIns\\Device'\"",
+    "install_time": {
+        "kit": "after",
+        "driver": "before"
+    }
+ }

--- a/WDTFNetData_1809/hlk1809server-config.json
+++ b/WDTFNetData_1809/hlk1809server-config.json
@@ -1,0 +1,10 @@
+{
+    "download_url": "",
+    "file_name": "WDTFNetData.dll",
+    "install_cmd": "powershell",
+    "install_args": "-Command \"Copy-Item -Path @sw_path@\\@file_name@ -Destination 'C:\\Program Files\\Windows Kits\\10\\Testing\\Runtimes\\WDTF\\RunTime\\DataPlugIns\\Device'\"",
+    "install_time": {
+        "kit": "after",
+        "driver": "before"
+    }
+ }


### PR DESCRIPTION
HLK Studio for Windows Server 2019 and Windows 10 1809 contain
a bug with the PNP Surprise removal test. MS provided an updated binary
that should solve the failure.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>