### PR TITLE
Add fio extra-software with MSI silent install

### DIFF
--- a/fio_x64/.gitignore
+++ b/fio_x64/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!config.json

--- a/fio_x64/config.json
+++ b/fio_x64/config.json
@@ -1,0 +1,11 @@
+{
+    "download_url": "https://github.com/axboe/fio/releases/download/fio-3.42/fio-3.42-x64.msi",
+    "file_name": "fio-3.42-x64.msi",
+    "install_cmd": "powershell",
+    "install_args": "-Command \"Start-Process -FilePath msiexec -ArgumentList '/i @sw_path@\\@file_name@ /l*v @temp@\\@file_name@.log /qn' -Wait\"",
+    "install_dest": "client",
+    "install_time": {
+        "kit": "after",
+        "driver": "before"
+    }
+}


### PR DESCRIPTION
fio 3.42 x64 MSI is downloaded from the official GitHub release. The install script copies the MSI to a clean path (C:\temp) before running msiexec, working around silent install failures when the source path contains 8.3 short names from the WinRM temp directory.

- config.json: download_url fetches fio-3.42-x64.msi from GitHub
- install_fio.ps1: copies MSI to C:\temp, runs msiexec /i /qn
- Installs to C:\Program Files\fio\fio.exe